### PR TITLE
Add support for /contrib (non-PGXS) builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 MODULES = pgextwlist
 DOCS    = README.md
 
+ifdef USE_PGXS
 PG_CONFIG = pg_config
-PGXS = $(shell $(PG_CONFIG) --pgxs)
+PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/pgextwlist
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ If that's not the case:
 1. install the server development packages (on Ubuntu, this would look like `apt-get install postgresql-server-dev-all`)
 2. then:
 
-    make
-    sudo make install
+    make USE_PGXS=1
+    sudo make USE_PGXS=1 install
 
 This will generate a `pgextwlist.so` shared library that you will have to
 install in
@@ -26,6 +26,12 @@ install in
     `pg_config --libdir`/plugins
 
 so that your backend loads it automatically.
+
+This is the preferred approach to installing pgextwlist. Alternatively, you may
+build pgextwlist from the contrib subdirectory of the main PostgreSQL source
+code tree. In that case, the pgextlist directory should be moved into contrib/
+before building, and the above instructions should be followed with
+`USE_PGXS=1` ommitted.
 
 ## Setup
 


### PR DESCRIPTION
This adds support for non-PGXS builds. Seems like we should stick to the convention of having to explicitly request a PGXS build by appending USE_PGXS=1 to make. The contrib Makefiles themselves require this, as do the Makefiles of popular third party modules like repmgr.
