### PR TITLE
Ensure that post-install hook scripts run correctly on 9.4 and up.

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -407,7 +407,7 @@ execute_sql_string(const char *sql, const char *filename)
 			}
 			else
 			{
-#if PG_MAJOR_VERSION == 903
+#if PG_MAJOR_VERSION >= 903
 				ProcessUtility(stmt,
 							   sql,
 							   PROCESS_UTILITY_QUERY,


### PR DESCRIPTION
Fixes #20.

Thanks for the debugging help @petergeoghegan