### PR TITLE
Fix an ALTER EXTENSION UPDATE crash

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -46,6 +46,7 @@
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
+#include "utils/tqual.h"
 
 /*
  * Parse contents of primary or auxiliary control file, and fill in
@@ -187,7 +188,7 @@ get_extension_current_version(const char *extname)
 				CStringGetDatum(extname));
 
 	extScan = systable_beginscan(extRel, ExtensionNameIndexId, true,
-								 NULL, 1, key);
+								 SnapshotSelf, 1, key);
 
 	extTup = systable_getnext(extScan);
 


### PR DESCRIPTION
Caused by using a NULL snapshot.  Annotated stack trace in a debug build
is as follows:

    0  0x00007fee33fcea8a in heap_hot_search_buffer (tid=0x7fee3494e914,
       relation=0x7fee33e95f80, buffer=8011, snapshot=0x0,
                                             ^^^^^^^^^^^^^ Problem
       heapTuple=0x7fee3494e910, all_dead=0x7fffa8f07842 "\001\001",
       first_call=1 '\001') at heapam.c:1735
    1  0x00007fee33fea959 in index_fetch_heap (scan=0x7fee3494e8c0)
       at indexam.c:529
    2  0x00007fee33feabcb in index_getnext (scan=0x7fee3494e8c0,
       direction=ForwardScanDirection) at indexam.c:612
    3  0x00007fee33fe91e3 in systable_getnext (sysscan=0x7fee3494edc8)
       at genam.c:390
    4  0x00007fec18156708 in get_extension_current_version (
       extname=extname@entry=0x7fee34942210 "postgis") at utils.c:192
    5  0x00007fec18157349 in extwlist_ProcessUtility (parsetree=0x7fee34942230,
       queryString=0x7fee349417f8 "alter extension  postgis update;",
       context=PROCESS_UTILITY_TOPLEVEL, params=0x0, dest=0x7fee349425b8,
       completionTag=0x7fffa8f07ce0 "") at pgextwlist.c:285
    6  0x00007fee342d0da2 in ProcessUtility (parsetree=0x7fee34942230,
       queryString=0x7fee349417f8 "alter extension  postgis update;",
       context=PROCESS_UTILITY_TOPLEVEL, params=0x0, dest=0x7fee349425b8,
       completionTag=0x7fffa8f07ce0 "") at utility.c:305
    7  0x00007fee342cfd75 in PortalRunUtility (portal=0x7fee3494c478,
       utilityStmt=0x7fee34942230, isTopLevel=1 '\001', dest=0x7fee349425b8,
       completionTag=0x7fffa8f07ce0 "") at pquery.c:1187
    8  0x00007fee342cff69 in PortalRunMulti (portal=0x7fee3494c478,
       isTopLevel=1 '\001', dest=0x7fee349425b8, altdest=0x7fee349425b8,
       completionTag=0x7fffa8f07ce0 "") at pquery.c:1318
    9  0x00007fee342cf422 in PortalRun (portal=0x7fee3494c478,
       count=9223372036854775807, isTopLevel=1 '\001', dest=0x7fee349425b8,
       altdest=0x7fee349425b8, completionTag=0x7fffa8f07ce0 "") at pquery.c:816
    10 0x00007fee342c8962 in exec_simple_query (
       query_string=0x7fee349417f8 "alter extension  postgis update;")
       at postgres.c:1075
    11 0x00007fee342cd370 in PostgresMain (argc=1, argv=0x7fee349298a8,
       dbname=0x7fee34929708 "REDACTED",
       username=0x7fee349296e0 "REDACTED") at postgres.c:4067
    12 0x00007fee34262868 in BackendRun (port=0x7fee3496ebf0)
       at postmaster.c:4049
    13 0x00007fee34261e88 in BackendStartup (port=0x7fee3496ebf0)
       at postmaster.c:3723
    14 0x00007fee3425e420 in ServerLoop () at postmaster.c:1613
    15 0x00007fee3425da72 in PostmasterMain (argc=5, argv=0x7fee34928390)
       at postmaster.c:1274
    16 0x00007fee341bfec6 in main (argc=5, argv=0x7fee34928390) at main.c:227