### PR TITLE
PG 9.5 compatibility and rpm packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+short_ver = 1.3
+long_ver = $(shell (git describe --tags --long '--match=v*' 2>/dev/null || echo $(short_ver)-0-unknown) | cut -c2-)
+
 MODULE_big = pgextwlist
 OBJS       = utils.o pgextwlist.o
 DOCS       = README.md
@@ -15,3 +18,13 @@ deb:
 	cd $(DEBUILD_ROOT) && make -f debian/rules orig
 	cd $(DEBUILD_ROOT) && debuild -us -uc -sa
 	cp -a /tmp/pgextwlist_* /tmp/postgresql-9.* build/
+
+rpm:
+	git archive --output=pgextwlist-rpm-src.tar.gz --prefix=pgextwlist/ HEAD
+	rpmbuild -bb pgextwlist.spec \
+		--define '_sourcedir $(CURDIR)' \
+		--define 'package_prefix $(package_prefix)' \
+		--define 'pkglibdir $(shell $(PG_CONFIG) --pkglibdir)' \
+		--define 'major_version $(short_ver)' \
+		--define 'minor_version $(subst -,.,$(subst $(short_ver)-,,$(long_ver)))'
+	$(RM) pgextwlist-rpm-src.tar.gz

--- a/pgextwlist.spec
+++ b/pgextwlist.spec
@@ -1,0 +1,40 @@
+Name:           %{?package_prefix}pgextwlist
+Version:        %{major_version}
+Release:        %{minor_version}%{?dist}
+Summary:        PostgreSQL Extension Whitelist extension
+
+Group:          Applications/Databases
+License:        PostgreSQL
+Requires:       %{?package_prefix}%{!?package_prefix:postgresql-}server
+BuildRequires:  %{?package_prefix}%{!?package_prefix:postgresql-}devel
+Source0:        pgextwlist-rpm-src.tar.gz
+
+%description
+This extension implements extension whitelisting, and will actively prevent
+users from installing extensions not in the provided list.  Also, this
+extension implements a form of sudo facility in that the whitelisted
+extensions will get installed as if superuser.  Privileges are dropped
+before handing the control back to the user.
+
+%prep
+%setup -q -n pgextwlist
+
+%build
+sed '/^DOCS/d' -i Makefile  # don't install README.md in pgsql/contrib
+make
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=%{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%doc README.md
+%{?pkglibdir}%{!?pkglibdir:%{_libdir}/pgsql}/pgextwlist.so
+
+%changelog
+* Tue Jul 14 2015 Oskari Saarenmaa <os@ohmu.fi> - 1.3-0
+- Initial.


### PR DESCRIPTION
PG 9.5 added another argument to GetUserNameFromId and set_config_option functions which we must set and made the read_binary_file function static so we'll just reimplement it in utils.c for all PG versions.

Also added an rpm .spec file and a Makefile target which can be used to build pgextwlist on (at least) Fedora systems using Fedora's or PGDG's PostgreSQL packages.