### PR TITLE
rpm: Change rpm spec so it includes bitcode files for PG11+

### DIFF
--- a/pgextwlist.spec
+++ b/pgextwlist.spec
@@ -33,7 +33,7 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %doc README.md
-%{?pkglibdir}%{!?pkglibdir:%{_libdir}/pgsql}/pgextwlist.so
+%{?pkglibdir}%{!?pkglibdir:%{_libdir}/pgsql}/
 
 %changelog
 * Sun Oct 15 2017 Christoph Berg <myon@debian.org> - 1.6-0


### PR DESCRIPTION
PG11+ may include bitcode files from LLVM, include them.