### PR TITLE
Support PG14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-short_ver = 1.9
+short_ver = $(shell git describe --match "v[0-9]*" --abbrev=4 HEAD | cut -d- -f1 | sed 's/^v//')
 long_ver = $(shell (git describe --tags --long '--match=v*' 2>/dev/null || echo $(short_ver)-0-unknown) | cut -c2-)
 
 MODULE_big = pgextwlist
 OBJS       = utils.o pgextwlist.o
 DOCS       = README.md
 REGRESS    = pgextwlist crossuser
+RPM_MINOR_VERSION_SUFFIX ?=
 
 PG_CONFIG = pg_config
 PGXS = $(shell $(PG_CONFIG) --pgxs)
@@ -26,5 +27,5 @@ rpm:
 		--define 'package_prefix $(package_prefix)' \
 		--define 'pkglibdir $(shell $(PG_CONFIG) --pkglibdir)' \
 		--define 'major_version $(short_ver)' \
-		--define 'minor_version $(subst -,.,$(subst $(short_ver)-,,$(long_ver)))'
+		--define 'minor_version $(subst -,.,$(subst $(short_ver)-,,$(long_ver)))$(RPM_MINOR_VERSION_SUFFIX)'
 	$(RM) pgextwlist-rpm-src.tar.gz

--- a/pgextwlist.c
+++ b/pgextwlist.c
@@ -101,7 +101,7 @@ void		_PG_fini(void);
 
 #define PROCESS_UTILITY_ARGS pstmt, queryString, context, \
                               params, queryEnv, dest, completionTag
-#else
+#elif PG_MAJOR_VERSION < 1400
 #define PROCESS_UTILITY_PROTO_ARGS PlannedStmt *pstmt,                    \
 										const char *queryString,       \
 										ProcessUtilityContext context, \
@@ -109,8 +109,18 @@ void		_PG_fini(void);
 										QueryEnvironment *queryEnv,    \
 										DestReceiver *dest,            \
 										QueryCompletion *qc
-
 #define PROCESS_UTILITY_ARGS pstmt, queryString, context, \
+                              params, queryEnv, dest, qc
+#else
+#define PROCESS_UTILITY_PROTO_ARGS PlannedStmt *pstmt,                    \
+										const char *queryString,       \
+										bool readOnlyTree,             \
+										ProcessUtilityContext context, \
+										ParamListInfo params,          \
+										QueryEnvironment *queryEnv,    \
+										DestReceiver *dest,            \
+										QueryCompletion *qc
+#define PROCESS_UTILITY_ARGS pstmt, queryString, readOnlyTree, context, \
                               params, queryEnv, dest, qc
 #endif	/* PG_MAJOR_VERSION */
 

--- a/utils.c
+++ b/utils.c
@@ -470,6 +470,9 @@ execute_sql_string(const char *sql, const char *filename)
 			{
 				ProcessUtility(stmt,
 							   sql,
+#if PG_MAJOR_VERSION >= 1400
+							   false,		/* no need to copy */
+#endif
 #if PG_MAJOR_VERSION >= 903
 							   PROCESS_UTILITY_QUERY,
 #endif


### PR DESCRIPTION
Since PG14, the process utility API needs a new argument, making it
explicit if a copy of the tree should be performed.