### PR TITLE
Use a dedicated memory context for executing custom scripts.

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -47,6 +47,7 @@
 #include "tcop/pquery.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
+#include "utils/memutils.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
@@ -385,6 +386,10 @@ execute_sql_string(const char *sql, const char *filename)
 	List	   *raw_parsetree_list;
 	DestReceiver *dest;
 	ListCell   *lc1;
+	MemoryContext temp_ctx = AllocSetContextCreate(CurrentMemoryContext,
+												   "temp_script_context",
+												   ALLOCSET_DEFAULT_SIZES);
+	MemoryContext prev_ctx = MemoryContextSwitchTo(temp_ctx);
 
 	/*
 	 * Parse the SQL string into a list of raw parse trees.
@@ -493,6 +498,8 @@ execute_sql_string(const char *sql, const char *filename)
 
 	/* Be sure to advance the command counter after the last script command */
 	CommandCounterIncrement();
+	MemoryContextSwitchTo(prev_ctx);
+	MemoryContextDelete(temp_ctx);
 }
 
 /*


### PR DESCRIPTION
This provides better isolation for the execution of custom scripts: the
memory allocated by the parse / plan / execute cycle will be released
early.

The real benefit of this is that the memory manager hooks will be called
once the context is freed. In particular, this helps an extension like
pgaudit which plugs it's events stack lifecycle on the memory context
associated to it. This was found out the hard way when pgaudit started
to complain about having a stack of events even though it was trying to
log a top-level query.