### PR TITLE
Support hooks on dropping extensions

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -6,6 +6,7 @@ jobs:
     strategy:
       matrix:
         pg:
+          - 16
           - 15
           - 14
           - 13

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ long_ver = $(shell (git describe --tags --long '--match=v*' 2>/dev/null || echo 
 MODULE_big = pgextwlist
 OBJS       = utils.o pgextwlist.o
 DOCS       = README.md
-REGRESS    = setup pgextwlist crossuser
+REGRESS    = setup pgextwlist crossuser hooks
 RPM_MINOR_VERSION_SUFFIX ?=
 
 PG_CONFIG = pg_config

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Even if you're not superuser:
     ----------
      f
     (1 row)
-    
+
     dim=> create extension hstore;
     create extension hstore;
     WARNING:  => is deprecated as an operator name
@@ -141,39 +141,51 @@ usage to the *current_user* or even the *database owner*, depending.
 The custom scripts feature allows to do that by providing scripts to be run
 around the execution of the extension's script itself.
 
-#### create extension custom scripts
+#### `create extension` custom scripts
 
 For the creation of extension `extname` version `1.0` the following scripts
 will be used when they do exist, as shown here:
 
-  #. `${extwlist.custom_path}/extname/before--1.0.sql`
+  - `${extwlist.custom_path}/extname/before--1.0.sql`
 
-  #. `${extwlist.custom_path}/extname/before-create.sql`, only when the
+  - `${extwlist.custom_path}/extname/before-create.sql`, only when the
      previous one, specific to the version being installed, does not exists.
-	
-  #. The `CREATE EXTENSION` command now runs normally
 
-  #. `${extwlist.custom_path}/extname/after--1.0.sql`
+  - The `CREATE EXTENSION` command now runs normally
 
-  #. `${extwlist.custom_path}/extname/after-create.sql`
+  - `${extwlist.custom_path}/extname/after--1.0.sql`
 
-#### alter extension update custom scripts
+  - `${extwlist.custom_path}/extname/after-create.sql`, only when the
+    specific one does not exist
+
+#### `alter extension update` custom scripts
 
 For the update of extension `extname` from version `1.0` to version `1.1`
 the following scripts will be used when they do exist, as shown here:
 
-  #. `${extwlist.custom_path}/extname/before--1.0--1.1.sql`
+  - `${extwlist.custom_path}/extname/before--1.0--1.1.sql`
 
-  #. `${extwlist.custom_path}/extname/before-update.sql`, only when the
-   previous one does not exists.
-	
-  #. The `ALTER EXTENSION UPDATE` command now runs normally
+  - `${extwlist.custom_path}/extname/before-update.sql`, only when the
+     specific one does not exists.
 
-  #. `${extwlist.custom_path}/extname/after--1.0--1.1.sql`
+  - The `ALTER EXTENSION UPDATE` command now runs normally
 
-  #. `${extwlist.custom_path}/extname/after-update.sql` only when the
-     previous one, specific to the versions being considered, does not
-     exists.
+  - `${extwlist.custom_path}/extname/after--1.0--1.1.sql`
+
+  - `${extwlist.custom_path}/extname/after-update.sql` only when the
+     specific one does not exists.
+
+#### `comment on extension` and `drop extension` scripts
+
+Similarly:
+
+   - `${extwlist.custom_path}/extname/before-comment.sql`
+   - `${extwlist.custom_path}/extname/after-comment.sql`
+
+   - `${extwlist.custom_path}/extname/before-drop.sql`
+   - `${extwlist.custom_path}/extname/after-drop.sql`
+
+Version-specific hook files are not supported here.
 
 #### custom scripts templating
 
@@ -187,7 +199,7 @@ substitutions to the *custom scripts*:
 
   - the literal `@current_user@` is replaced by the name of the current
     user,
-	
+
   - the literal `@database_owner@` is replaced by the name of the current
     database owner.
 

--- a/expected/hooks.out
+++ b/expected/hooks.out
@@ -1,0 +1,25 @@
+set client_min_messages = debug;
+set extwlist.custom_path = '/dummy';
+set role mere_mortal;
+-- in the hope refint stays at version 1.0 in PostgreSQL
+create extension refint;
+DEBUG:  Considering custom script "/dummy/refint/before--1.0.sql"
+DEBUG:  Considering custom script "/dummy/refint/before-create.sql"
+DEBUG:  Considering custom script "/dummy/refint/after--1.0.sql"
+DEBUG:  Considering custom script "/dummy/refint/after-create.sql"
+alter extension refint update;
+DEBUG:  Considering custom script "/dummy/refint/before--1.0--1.0.sql"
+DEBUG:  Considering custom script "/dummy/refint/before-update.sql"
+NOTICE:  version "1.0" of extension "refint" is already installed
+DEBUG:  Considering custom script "/dummy/refint/after--1.0--1.0.sql"
+DEBUG:  Considering custom script "/dummy/refint/after-update.sql"
+comment on extension refint is 'snarky remark';
+DEBUG:  Considering custom script "/dummy/refint/before-comment.sql"
+DEBUG:  Considering custom script "/dummy/refint/after-comment.sql"
+drop extension refint, refint;
+DEBUG:  Considering custom script "/dummy/refint/before-drop.sql"
+DEBUG:  Considering custom script "/dummy/refint/before-drop.sql"
+DEBUG:  drop auto-cascades to function check_primary_key()
+DEBUG:  drop auto-cascades to function check_foreign_key()
+DEBUG:  Considering custom script "/dummy/refint/after-drop.sql"
+DEBUG:  Considering custom script "/dummy/refint/after-drop.sql"

--- a/expected/pgextwlist.out
+++ b/expected/pgextwlist.out
@@ -1,9 +1,8 @@
-CREATE ROLE mere_mortal;
 SET ROLE mere_mortal;
 SHOW extwlist.extensions;
-               extwlist.extensions               
--------------------------------------------------
- citext,earthdistance,pg_trgm,pg_stat_statements
+                  extwlist.extensions                   
+--------------------------------------------------------
+ citext,earthdistance,pg_trgm,pg_stat_statements,refint
 (1 row)
 
 SELECT extname FROM pg_extension ORDER BY 1;

--- a/expected/pgextwlist_1.out
+++ b/expected/pgextwlist_1.out
@@ -1,9 +1,8 @@
-CREATE ROLE mere_mortal;
 SET ROLE mere_mortal;
 SHOW extwlist.extensions;
-               extwlist.extensions               
--------------------------------------------------
- citext,earthdistance,pg_trgm,pg_stat_statements
+                  extwlist.extensions                   
+--------------------------------------------------------
+ citext,earthdistance,pg_trgm,pg_stat_statements,refint
 (1 row)
 
 SELECT extname FROM pg_extension ORDER BY 1;

--- a/expected/pgextwlist_2.out
+++ b/expected/pgextwlist_2.out
@@ -1,9 +1,8 @@
-CREATE ROLE mere_mortal;
 SET ROLE mere_mortal;
 SHOW extwlist.extensions;
-               extwlist.extensions               
--------------------------------------------------
- citext,earthdistance,pg_trgm,pg_stat_statements
+                  extwlist.extensions                   
+--------------------------------------------------------
+ citext,earthdistance,pg_trgm,pg_stat_statements,refint
 (1 row)
 
 SELECT extname FROM pg_extension ORDER BY 1;

--- a/expected/setup.out
+++ b/expected/setup.out
@@ -1,6 +1,6 @@
 LOAD 'pgextwlist';
 ALTER SYSTEM SET session_preload_libraries='pgextwlist';
-ALTER SYSTEM SET extwlist.extensions='citext,earthdistance,pg_trgm,pg_stat_statements';
+ALTER SYSTEM SET extwlist.extensions='citext,earthdistance,pg_trgm,pg_stat_statements,refint';
 \set testdir `pwd` '/test-scripts'
 ALTER SYSTEM SET extwlist.custom_path=:'testdir';
 SELECT pg_reload_conf();
@@ -9,3 +9,4 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+CREATE ROLE mere_mortal;

--- a/pgextwlist.c
+++ b/pgextwlist.c
@@ -251,7 +251,7 @@ extension_is_whitelisted(const char *name)
 	{
 		char *curext = (char *) lfirst(lc);
 
-		if (!strcmp(name, curext))
+		if (strcmp(name, curext) == 0)
 		{
 			whitelisted = true;
 			break;
@@ -427,7 +427,7 @@ call_ProcessUtility(PROCESS_UTILITY_PROTO_ARGS,
 	if (action)
 	{
 		/* "drop extension" can list several extensions, walk them here */
-		if (!strcmp(action, "drop"))
+		if (strcmp(action, "drop") == 0)
 		{
 			Node   *parsetree = pstmt->utilityStmt;
 			ListCell *lc;
@@ -456,7 +456,7 @@ call_ProcessUtility(PROCESS_UTILITY_PROTO_ARGS,
 
 	if (action)
 	{
-		if (!strcmp(action, "drop"))
+		if (strcmp(action, "drop") == 0)
 		{
 			Node   *parsetree = pstmt->utilityStmt;
 			ListCell *lc;

--- a/sql/hooks.sql
+++ b/sql/hooks.sql
@@ -1,0 +1,9 @@
+set client_min_messages = debug;
+set extwlist.custom_path = '/dummy';
+set role mere_mortal;
+
+-- in the hope refint stays at version 1.0 in PostgreSQL
+create extension refint;
+alter extension refint update;
+comment on extension refint is 'snarky remark';
+drop extension refint, refint;

--- a/sql/pgextwlist.sql
+++ b/sql/pgextwlist.sql
@@ -1,4 +1,3 @@
-CREATE ROLE mere_mortal;
 SET ROLE mere_mortal;
 
 SHOW extwlist.extensions;

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -1,6 +1,8 @@
 LOAD 'pgextwlist';
 ALTER SYSTEM SET session_preload_libraries='pgextwlist';
-ALTER SYSTEM SET extwlist.extensions='citext,earthdistance,pg_trgm,pg_stat_statements';
+ALTER SYSTEM SET extwlist.extensions='citext,earthdistance,pg_trgm,pg_stat_statements,refint';
 \set testdir `pwd` '/test-scripts'
 ALTER SYSTEM SET extwlist.custom_path=:'testdir';
 SELECT pg_reload_conf();
+
+CREATE ROLE mere_mortal;

--- a/utils.c
+++ b/utils.c
@@ -128,11 +128,9 @@ parse_default_version_in_control_file(const char *extname,
 /*
  * We lookup scripts at the following places and run them when they exist:
  *
- *  ${extwlist_custom_path}/${extname}/${when}--${version}.sql
- *  ${extwlist_custom_path}/${extname}/${when}-${action}.sql
- *
- * - action is expected to be either "create" or "update"
- * - when   is expected to be either "before" or "after"
+ *  ${extwlist_custom_path}/${extname}/${when}--${version}.sql (upgrade)
+ *  ${extwlist_custom_path}/${extname}/${when}-${action}.sql (create)
+ *  ${extwlist_custom_path}/${extname}/${when}-${action}--${version}.sql (rest)
  */
 char *
 get_generic_custom_script_filename(const char *name,


### PR DESCRIPTION
Extend the existing hook logic to support dropping extensions and comments on extensions as well. Since several extensions can be dropped from one command, we have to add code to walk the parse tree while privileges are elevated.

Drop and comment hooks do not support version-specific files, that would require catalog access which didn't seem required yet.

Close #48.